### PR TITLE
nslsii patch

### DIFF
--- a/recipes/nslsii/0001-import-bluesky_kafka-only-when-needed.patch
+++ b/recipes/nslsii/0001-import-bluesky_kafka-only-when-needed.patch
@@ -1,0 +1,33 @@
+From 6fc06a9b42e73df6fa73b6cf28cb77b37921ae34 Mon Sep 17 00:00:00 2001
+From: Joshua Lynch <jlynch@bnl.gov>
+Date: Thu, 22 Jul 2021 17:28:29 -0400
+Subject: [PATCH] import bluesky_kafka only when needed
+
+---
+ nslsii/__init__.py | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/nslsii/__init__.py b/nslsii/__init__.py
+index 54bfe21..999871e 100644
+--- a/nslsii/__init__.py
++++ b/nslsii/__init__.py
+@@ -13,7 +13,6 @@ import msgpack_numpy as mpn
+ 
+ from IPython import get_ipython
+ 
+-from bluesky_kafka import Publisher
+ from event_model import RunRouter
+ 
+ from ._version import get_versions
+@@ -578,6 +577,8 @@ def subscribe_kafka_publisher(RE, beamline_name, bootstrap_servers, producer_con
+         by this function
+ 
+     """
++    from bluesky_kafka import Publisher
++
+     topic = f"{beamline_name.lower()}.bluesky.runengine.documents"
+ 
+     def kafka_publisher_factory(name, start_doc):
+-- 
+2.16.1
+

--- a/recipes/nslsii/meta.yaml
+++ b/recipes/nslsii/meta.yaml
@@ -8,11 +8,12 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: c409688657771291fb2c32e95045d3f44432402ebfb41dae5bc7188c1d34c075
+  patches:
+    - 0001-import-bluesky_kafka-only-when-needed.patch
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
-  skip: true  # [win]
 
 requirements:
   host:
@@ -36,11 +37,24 @@ requirements:
 test:
   imports:
     - nslsii
+    - nslsii._version
     - nslsii.ad33
+    - nslsii.common
+    - nslsii.common.ipynb
+    - nslsii.common.ipynb.animation
+    - nslsii.common.ipynb.info
+    - nslsii.common.ipynb.logutils
+    - nslsii.common.ipynb.nbviewer
+    - nslsii.detectors
+    - nslsii.detectors.trigger_mixins
+    - nslsii.detectors.utils
+    - nslsii.detectors.xspress3
+    - nslsii.detectors.zebra
     - nslsii.devices
+    - nslsii.iocs.eps_two_state_ioc_sim
+    - nslsii.iocs.thermo_sim
     - nslsii.temperature_controllers
     - nslsii.transforms
-    - nslsii._version
 
 about:
   home: https://github.com/NSLS-II/nslsii


### PR DESCRIPTION
This is a patch based on today's improvement to make `nslsii` importable on Windows - https://github.com/NSLS-II/nslsii/pull/124.

The patch was generated with the following command on the `master` branch of https://github.com/NSLS-II/nslsii:
```bash
$ git format-patch -1
```

Here is an updated command to get the import tests recursively:
```bash
$ git clone https://github.com/NSLS-II/nslsii.git
$ cd nslsii/
$ find nslsii -name "*.py" | grep -v tests | sed 's/.__init__.py//g' | sed 's;/;.;g' | sed 's/\.py$//g' | sort
```