### PR TITLE
`edrixs` with `openblas` fix

### DIFF
--- a/recipes/edrixs/meta.yaml
+++ b/recipes/edrixs/meta.yaml
@@ -17,23 +17,19 @@ requirements:
   build:
     - arpack
     - arpack-mpi
-    - libblas
     - openblas
     - openmpi
     - {{ compiler('fortran') }}
   host:
     - python
     - pip
-    - libopenblas
-    - openblas  # [not win]
-    - openmpi
-    - mkl  # [win]
+    - libblas * *openblas
     - numpy
     - openblas
   run:
     - python
     - arpack-mpi
-    - libopenblas
+    - libblas * *openblas
     - matplotlib-base
     - mpi4py
     - numpy

--- a/recipes/edrixs/meta.yaml
+++ b/recipes/edrixs/meta.yaml
@@ -15,7 +15,6 @@ build:
 
 requirements:
   build:
-    - arpack
     - arpack-mpi
     - openblas
     - openmpi


### PR DESCRIPTION
Fixes the recipe for `edrixs` from https://github.com/conda-forge/staged-recipes/pull/15729. Uses recommendations from https://conda-forge.org/docs/maintainer/knowledge_base.html?highlight=openblas#blas. Built successfully locally with Docker.